### PR TITLE
Fix data race between decoder and scanner

### DIFF
--- a/scanner_test.go
+++ b/scanner_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"io"
+	"sync/atomic"
 	"testing"
 )
 
@@ -19,7 +20,7 @@ func TestScanner(t *testing.T) {
 	var i int
 	r := bytes.NewReader(data)
 	scanner := newScanner(r)
-	for scanner.pos < scanner.end {
+	for scanner.pos < atomic.LoadInt64(&scanner.end) {
 		c := scanner.next()
 		if c != data[i] {
 			t.Fatalf("expected %s, got %s", string(data[i]), string(c))


### PR DESCRIPTION
This is a fix for a race detected between decoder go-routine and scanner.

```
WARNING: DATA RACE
Read at 0x00c000042a18 by goroutine 11:
  github.com/minio/minio/vendor/github.com/bcicen/jstream.(*Decoder).decode()
      /home/travis/gopath/src/github.com/minio/minio/vendor/github.com/bcicen/jstream/decoder.go:108 +0xeb
Previous write at 0x00c000042a18 by goroutine 10:
  github.com/minio/minio/vendor/github.com/bcicen/jstream.newScanner.func1()
      /home/travis/gopath/src/github.com/minio/minio/vendor/github.com/bcicen/jstream/scanner.go:41 +0x164
```

On current master it can be easily reproduced using `go test -v -race`, this PR fixes
this situation by atomically protecting the end offset value.