### PR TITLE
Propagate underlying reader errors

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -206,3 +206,32 @@ func TestDecoderMultiDoc(t *testing.T) {
 		t.Fatalf("expected 0 items, got %d", counter)
 	}
 }
+
+func TestDecoderReaderFailure(t *testing.T) {
+	var (
+		failAfter = 900
+		mockData  = byte('[')
+	)
+
+	r := newMockReader(failAfter, mockData)
+	decoder := NewDecoder(r, -1)
+
+	for mv := range decoder.Stream() {
+		t.Logf("depth=%d offset=%d len=%d (%v)", mv.Depth, mv.Offset, mv.Length, mv.Value)
+	}
+
+	err := decoder.Err()
+	t.Logf("got error: %s", err)
+	if err == nil {
+		t.Fatalf("missing expected decoder error")
+	}
+
+	derr, ok := err.(DecoderError)
+	if !ok {
+		t.Fatalf("expected error of type DecoderError, got %T", err)
+	}
+
+	if derr.ReaderErr() == nil {
+		t.Fatalf("missing expected underlying reader error")
+	}
+}


### PR DESCRIPTION
remove panic on unexpected reader errors, propagate up through decoder