### PR TITLE
Add max recursion depth

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -200,7 +200,7 @@ func (d *Decoder) any() (interface{}, ValueType, error) {
 		i, err := d.number()
 		return i, Number, err
 	case '-':
-		if c = d.next(); c < '0' && c > '9' {
+		if c = d.next(); c < '0' || c > '9' {
 			return nil, Unknown, d.mkError(ErrSyntax, "in negative numeric literal")
 		}
 		n, err := d.number()
@@ -374,7 +374,7 @@ func (d *Decoder) number() (float64, error) {
 		d.scratch.add(c)
 
 		// first char following must be digit
-		if c = d.next(); c < '0' && c > '9' {
+		if c = d.next(); c < '0' || c > '9' {
 			return 0, d.mkError(ErrSyntax, "after decimal point in numeric literal")
 		}
 		d.scratch.add(c)

--- a/errors.go
+++ b/errors.go
@@ -9,6 +9,7 @@ import (
 var (
 	ErrSyntax        = DecoderError{msg: "invalid character"}
 	ErrUnexpectedEOF = DecoderError{msg: "unexpected end of JSON input"}
+	ErrMaxDepth      = DecoderError{msg: "maximum recursion depth exceeded"}
 )
 
 type errPos [2]int // line number, byte offset where error occurred


### PR DESCRIPTION
Signature:

```
// MaxDepth will set the maximum recursion depth.
// If the maximum depth is exceeded, ErrMaxDepth is returned.
// Less than or 0 means no limit (default).
func (d *Decoder) MaxDepth(n int) *Decoder {
```

This can be used to prevent stack exhaustion on adversarial content.